### PR TITLE
chore: Fix psalm by setting PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"friendsofphp/php-cs-fixer": "^3",
 		"nextcloud/coding-standard": "^1",
 		"phpunit/phpunit": "^9.5",
-		"psalm/phar": "5.x.x",
+		"psalm/phar": "^5",
 		"nextcloud/ocp": "dev-master"
 	},
 	"scripts": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="1"
+    phpVersion="8.0"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
-    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    xsi:schemaLocation="https://getpsalm.org/schema/config https://getpsalm.org/schema/config"
     errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>


### PR DESCRIPTION
* [ ] chained onto #129 

Make psalm run with lowest supported PHP version

To have consistent psalm results the target PHP version should be set instead of guessed from currently running version.
Currently Nextcloud 28 is supported so lowest PHP version is 8.0.
    
Also the `schemaLocation` was set to a non-existing path, as the phar bundle is used the only available location would be the online version.