### PR TITLE
fix: catch file parsing errors to not fail entire request

### DIFF
--- a/lib/Service/BailsPolicyProviderService.php
+++ b/lib/Service/BailsPolicyProviderService.php
@@ -26,7 +26,11 @@ class BailsPolicyProviderService {
 			if (!in_array($mimeType, $provider->getSupportedMimeTypes())) {
 				continue;
 			}
-			return $provider->getPolicyForFile($file);
+			try {
+				return $provider->getPolicyForFile($file);
+			} catch (\Exception) {
+				return null;
+			}
 		}
 		return null;
 	}

--- a/lib/Service/BailsPolicyProviderService.php
+++ b/lib/Service/BailsPolicyProviderService.php
@@ -28,7 +28,7 @@ class BailsPolicyProviderService {
 			}
 			try {
 				return $provider->getPolicyForFile($file);
-			} catch (\Exception) {
+			} catch (\Throwable) {
 				return null;
 			}
 		}


### PR DESCRIPTION
If the parsing of file is failed due to any reason, we don't want to fail the request with Unhandled ValueError exception and should just skip the tagging then.