### PR TITLE
fix(ci): correct BafServiceTest.php

### DIFF
--- a/test/BafServiceTest.php
+++ b/test/BafServiceTest.php
@@ -24,16 +24,12 @@ class BafServiceTest extends TestCase {
 
 		$this->assertCount(4, $labels);
 
-		$this->assertEquals('Non-Business', $labels[0]->getKeywords()[0]);
 		$this->assertEquals('urn:example:tscp:1:non-business', $labels[0]->getBailsCategories()[0]);
 
-		$this->assertEquals('General Business', $labels[1]->getKeywords()[0]);
 		$this->assertEquals('urn:example:tscp:1:general-business', $labels[1]->getBailsCategories()[0]);
 
-		$this->assertEquals('Confidential', $labels[2]->getKeywords()[0]);
 		$this->assertEquals('urn:example:tscp:1:confidential', $labels[2]->getBailsCategories()[0]);
 
-		$this->assertEquals('Internal Only', $labels[3]->getKeywords()[0]);
 		$this->assertEquals('urn:example:tscp:1:internal-only', $labels[3]->getBailsCategories()[0]);
 	}
 }


### PR DESCRIPTION
Update test, since keywords are removed (https://github.com/nextcloud/files_confidential/commit/85a796c55de961c529f526fd70b895e5d7c27613)