### PR TITLE
Prepare 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.1] - 2026-06-24
+
+### Fixed
+
+- Create temp file copy without # when needed [#262](https://github.com/nextcloud/files_confidential/pull/262) @lukasdotcom
+- Update npm dependencies to fix security advisories [#244](https://github.com/nextcloud/files_confidential/pull/244)
+
 ## [4.1.0] - 2026-02-26
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@ This app allows you to define a set of classification rules that will assign tag
 For each classification rule you can define when the tag will be assigned to a file, based on text
 content, BAILS classification metadata or Microsoft Information Purview metadata.
 ]]></description>
-	<version>4.1.0</version>
+	<version>4.1.1</version>
 	<licence>agpl</licence>
 	<author mail="mklehr@gmx.net" homepage="https://marcelklehr.de">Marcel Klehr</author>
 	<namespace>Files_Confidential</namespace>

--- a/js/files_confidential-adminSettings.mjs.license
+++ b/js/files_confidential-adminSettings.mjs.license
@@ -100,7 +100,7 @@ This file is generated from multiple sources. Included packages:
 	- version: 1.0.3
 	- license: MIT
 - files_confidential
-	- version: 4.1.0
+	- version: 4.1.1
 	- license: AGPL-3.0-or-later
 - floating-vue
 	- version: 5.2.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "files_confidential",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "files_confidential",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/files": "^3.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "files_confidential",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "",
   "directories": {
     "lib": "lib",


### PR DESCRIPTION
## [4.1.1] - 2026-06-24

### Fixed

- Create temp file copy without # when needed [#262](https://github.com/nextcloud/files_confidential/pull/262) @lukasdotcom
- Update npm dependencies to fix security advisories [#244](https://github.com/nextcloud/files_confidential/pull/244)