### PR TITLE
Feature/classification priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ based on text content or TSCP/BAILS classification metadata.
 
 The assigned tags can then be used with the files_accesscontrol app to restrict access to specific groups of users.
 
+## Features
+
+* Define classification rules based on document content, metadata, or TSCP/BAILS policy categories
+* Import classification labels from a Business Authorization Framework (BAF) XML file
+* **Priority-based classification**: assign a priority value to each rule to control which takes precedence
+* **Multi-tag assignment**: when multiple rules match a document, all matching tags are applied (e.g. a file can be tagged as both "PII" and "Internal")
+* Integrate with Nextcloud Flow to automate actions based on classification tags
+
 
 ## Install
 * Place this app in **nextcloud/apps/**

--- a/lib/Contract/IClassificationLabel.php
+++ b/lib/Contract/IClassificationLabel.php
@@ -15,6 +15,14 @@ interface IClassificationLabel {
 	 * @return int
 	 */
 	public function getIndex(): int;
+
+	/**
+	 * The priority of the label (higher value = higher priority)
+	 * Used for determining which label takes precedence when multiple match
+	 * @return int
+	 */
+	public function getPriority(): int;
+
 	public function getTag(): string;
 
 	/**

--- a/lib/Listener/HookListener.php
+++ b/lib/Listener/HookListener.php
@@ -46,12 +46,13 @@ class HookListener implements IEventListener {
 					$fileTags = $this->tagMapper->getTagIdsForObjects($nodeId, 'files')[$nodeId] ?? [];
 					$knownAppliedTags = array_intersect($classificationTags, $fileTags); // Get all tags from file that files_confidential manages
 
-					// Find the tag that the file should be assigned to based on the classification policy
-					$label = $this->classificationService->getClassificationLabelForFile($node);
+					// Find all matching labels for the file based on classification rules
+					$matchedLabels = $this->classificationService->getClassificationLabelsForFile($node);
 
-					if ($label !== null) {
-						$this->tagMapper->assignTags($nodeId, 'files', [$label->getTag()]);
-						$knownAppliedTags = array_diff($knownAppliedTags, [$label->getTag()]); // Remove the tag that the file should be assigned to from the list of unnecessary tags
+					if (!empty($matchedLabels)) {
+						$matchedTags = array_map(static fn ($label) => $label->getTag(), $matchedLabels);
+						$this->tagMapper->assignTags($nodeId, 'files', $matchedTags);
+						$knownAppliedTags = array_diff($knownAppliedTags, $matchedTags);
 					}
 
 					$this->tagMapper->unassignTags($nodeId, 'files', array_values($knownAppliedTags));

--- a/lib/Model/ClassificationLabel.php
+++ b/lib/Model/ClassificationLabel.php
@@ -15,6 +15,7 @@ use OCA\Files_Confidential\Service\MatcherService;
 class ClassificationLabel implements IClassificationLabel {
 	private string $tag;
 	private int $index;
+	private int $priority;
 	/**
 	 * @var list<string>
 	 */
@@ -100,8 +101,9 @@ class ClassificationLabel implements IClassificationLabel {
 	 * @param list<string> $searchExpressions
 	 * @param list<string> $regularExpressions
 	 * @param MetadataItem[] $metadataItems
+	 * @param int $priority
 	 */
-	public function __construct(int $index, string $tag, array $keywords, array $categories, array $searchExpressions, array $regularExpressions, array $metadataItems) {
+	public function __construct(int $index, string $tag, array $keywords, array $categories, array $searchExpressions, array $regularExpressions, array $metadataItems, int $priority = 0) {
 		$this->index = $index;
 		$this->tag = $tag;
 		$this->keywords = $keywords;
@@ -109,10 +111,11 @@ class ClassificationLabel implements IClassificationLabel {
 		$this->searchExpressions = $searchExpressions;
 		$this->regularExpressions = $regularExpressions;
 		$this->metadataItems = $metadataItems;
+		$this->priority = $priority;
 	}
 
 	/**
-	 * @param array{index:int, tag:string, keywords:list<string>, categories:list<string>, searchExpressions:list<string>, regularExpressions:list<string>, metadataItems: list<array{key: string, value: string}>} $labelRaw
+	 * @param array{index:int, tag:string, keywords:list<string>, categories:list<string>, searchExpressions:list<string>, regularExpressions:list<string>, metadataItems: list<array{key: string, value: string}>, priority?: int} $labelRaw
 	 *
 	 * @throws \ValueError
 	 */
@@ -121,7 +124,8 @@ class ClassificationLabel implements IClassificationLabel {
 			throw new \ValueError();
 		}
 		$metadata = array_values(array_filter(array_map(fn ($item) => MetadataItem::fromArray($item), $labelRaw['metadataItems'] ?? []), fn ($item) => $item->getKey() !== ''));
-		return new ClassificationLabel($labelRaw['index'], $labelRaw['tag'], $labelRaw['keywords'], $labelRaw['categories'], $labelRaw['searchExpressions'], $labelRaw['regularExpressions'], $metadata);
+		$priority = max(0, min(100, (int)($labelRaw['priority'] ?? 0)));
+		return new ClassificationLabel($labelRaw['index'], $labelRaw['tag'], $labelRaw['keywords'], $labelRaw['categories'], $labelRaw['searchExpressions'], $labelRaw['regularExpressions'], $metadata, $priority);
 	}
 
 	#[\Override]
@@ -129,6 +133,7 @@ class ClassificationLabel implements IClassificationLabel {
 		return [
 			'index' => $this->getIndex(),
 			'tag' => $this->getTag(),
+			'priority' => $this->getPriority(),
 			'keywords' => $this->getKeywords(),
 			'categories' => $this->getBailsCategories(),
 			'searchExpressions' => $this->getSearchExpressions(),
@@ -140,6 +145,11 @@ class ClassificationLabel implements IClassificationLabel {
 	#[\Override]
 	public function getIndex(): int {
 		return $this->index;
+	}
+
+	#[\Override]
+	public function getPriority(): int {
+		return $this->priority;
 	}
 
 	#[\Override]

--- a/lib/Service/ClassificationService.php
+++ b/lib/Service/ClassificationService.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace OCA\Files_Confidential\Service;
 
 use OCA\Files_Confidential\Contract\IClassificationLabel;
-use OCA\Files_Confidential\Model\ClassificationLabel;
+use OCA\Files_Confidential\Model\MetadataItem;
 use OCP\Files\File;
 
 class ClassificationService {
@@ -23,52 +23,125 @@ class ClassificationService {
 	) {
 	}
 
+	/**
+	 * Get the single highest-priority classification label matching a file.
+	 * Returns the first label from getClassificationLabelsForFile() or null if none match.
+	 *
+	 * @param File $file
+	 * @return IClassificationLabel|null The highest-priority matching label, or null
+	 */
 	public function getClassificationLabelForFile(File $file) : ?IClassificationLabel {
+		$labels = $this->getClassificationLabelsForFile($file);
+		return $labels[0] ?? null;
+	}
+
+	/**
+	 * Get all matching classification labels for a file, sorted by priority (highest first).
+	 * Unlike getClassificationLabelForFile() which returns only the top match,
+	 * this method returns every label whose rules matched the file content,
+	 * metadata, or BAILS policy — enabling multi-tag assignment.
+	 *
+	 * @param File $file
+	 * @return IClassificationLabel[] All matching labels sorted by priority desc, then index asc
+	 */
+	public function getClassificationLabelsForFile(File $file): array {
 		$labels = $this->settings->getClassificationLabels();
 		if (empty($labels)) {
-			return null;
+			return [];
 		}
 
 		$bailsPolicy = $this->bailsService->getPolicyForFile($file);
-		$labelFromPolicy = null;
+		$labelsFromPolicy = [];
 		if ($bailsPolicy !== null) {
 			foreach ($labels as $label) {
 				if (count($label->getBailsCategories()) === 0) {
 					continue;
 				}
+				$allCategoriesMatch = true;
 				foreach ($label->getBailsCategories() as $categoryId) {
-					// All defined categories for this label must be assigned to the document for the label to be applied
 					if (!in_array($categoryId, array_map(static fn ($cat) => $cat->getId(), $bailsPolicy->getCategories()), true)) {
-						continue 2;
+						$allCategoriesMatch = false;
+						break;
 					}
 				}
-				$labelFromPolicy = $label;
+				if ($allCategoriesMatch) {
+					$labelsFromPolicy[] = $label;
+				}
 			}
 		}
 
 		$metadata = $this->metadataService->getMetadataForFile($file);
-		$labelFromMetadata = ClassificationLabel::findLabelsInMetadata($metadata, $labels);
+		$labelsFromMetadata = $this->findAllLabelsInMetadata($metadata, $labels);
 
-		$labelFromContent = $this->findLabelInStream($file, $labels);
+		$labelsFromContent = $this->findAllLabelsInStream($file, $labels);
 
 		/** @var IClassificationLabel[] $foundLabels */
-		$foundLabels = array_values(array_filter([$labelFromMetadata, $labelFromPolicy, $labelFromContent], static fn ($label) => $label !== null));
+		$foundLabels = array_values(array_unique(
+			array_merge($labelsFromPolicy, $labelsFromMetadata, $labelsFromContent),
+			SORT_REGULAR
+		));
 
 		if (count($foundLabels) === 0) {
-			return null;
+			return [];
 		}
 
+		// Sort by priority descending (higher priority first), then by index ascending as tiebreaker
 		usort($foundLabels, function (IClassificationLabel $label1, IClassificationLabel $label2) {
+			if ($label1->getPriority() !== $label2->getPriority()) {
+				return $label2->getPriority() <=> $label1->getPriority();
+			}
 			return $label1->getIndex() <=> $label2->getIndex();
 		});
 
-		return $foundLabels[0];
+		return $foundLabels;
 	}
 
 	/**
-	 * @param IClassificationLabel[] $labels
+	 * Find all labels matching metadata
+	 *
+	 * @param MetadataItem[] $metadataItems
+	 * @param list<IClassificationLabel> $labels
+	 * @return IClassificationLabel[]
 	 */
-	private function findLabelInStream(File $file, array $labels): ?IClassificationLabel {
+	private function findAllLabelsInMetadata(array $metadataItems, array $labels): array {
+		$matched = [];
+		foreach ($labels as $label) {
+			if (count($label->getMetadataItems()) === 0) {
+				continue;
+			}
+			$matchedKeys = 0;
+			$allMatch = true;
+			foreach ($label->getMetadataItems() as $labelMetadataItem) {
+				$keyFound = false;
+				foreach ($metadataItems as $fileMetadataItem) {
+					if ($labelMetadataItem->getKey() === $fileMetadataItem->getKey()) {
+						$keyFound = true;
+						$matchedKeys++;
+						if ($labelMetadataItem->getValue() !== $fileMetadataItem->getValue()) {
+							$allMatch = false;
+							break 2;
+						}
+					}
+				}
+				if (!$keyFound) {
+					$allMatch = false;
+					break;
+				}
+			}
+			if ($allMatch && count($label->getMetadataItems()) === $matchedKeys && $matchedKeys > 0) {
+				$matched[] = $label;
+			}
+		}
+		return $matched;
+	}
+
+	/**
+	 * Find all matching labels in the file content stream
+	 *
+	 * @param IClassificationLabel[] $labels
+	 * @return IClassificationLabel[]
+	 */
+	private function findAllLabelsInStream(File $file, array $labels): array {
 		$patterns = [];
 		$captureMap = [];
 		$maxMatchLength = 0;
@@ -105,7 +178,7 @@ class ClassificationService {
 		}
 
 		if (empty($patterns)) {
-			return null;
+			return [];
 		}
 
 		$combinedRegex = '/' . implode('|', $patterns) . '/isu';
@@ -113,38 +186,37 @@ class ClassificationService {
 
 		$contentStream = $this->contentService->getContentStreamForFile($file);
 		$overlap = '';
+		$matchedLabels = [];
 
 		foreach ($contentStream as $chunk) {
 			$textToSearch = $overlap . $chunk;
 			$matches = [];
 
-			if (@preg_match($combinedRegex, $textToSearch, $matches) === 1) {
+			if (@preg_match_all($combinedRegex, $textToSearch, $matches) > 0) {
 				foreach ($captureMap as $captureName => $label) {
-					if (!empty($matches[$captureName])) {
-						// The first populated capture group corresponds to the highest-priority match.
-						return $label;
+					if (!empty($matches[$captureName]) && array_filter($matches[$captureName], fn ($m) => $m !== '')) {
+						$matchedLabels[spl_object_id($label)] = $label;
 					}
 				}
 			}
 
 			if ($overlapSize > 0) {
-				// Keep the last part of the text to search for overlaps in the next chunk
 				$overlap = substr($textToSearch, -$overlapSize);
 			}
 		}
 
-		// After the loop if we still here, check the final overlap for any trailing matches.
+		// Check the final overlap for any trailing matches
 		if (!empty($overlap)) {
 			$matches = [];
-			if (@preg_match($combinedRegex, $overlap, $matches) === 1) {
+			if (@preg_match_all($combinedRegex, $overlap, $matches) > 0) {
 				foreach ($captureMap as $captureName => $label) {
-					if (!empty($matches[$captureName])) {
-						return $label;
+					if (!empty($matches[$captureName]) && array_filter($matches[$captureName], fn ($m) => $m !== '')) {
+						$matchedLabels[spl_object_id($label)] = $label;
 					}
 				}
 			}
 		}
 
-		return null;
+		return array_values($matchedLabels);
 	}
 }

--- a/src/components/ClassificationLabel.vue
+++ b/src/components/ClassificationLabel.vue
@@ -27,6 +27,16 @@
 				:placeholder="t('files_confidential', 'Select tag')"
 				@input="$emit('change')" />
 		</label>
+		<label class="priority-label">
+			<span class="text">{{ t('files_confidential', 'Priority') }}</span>
+			<input v-model.number="label.priority"
+				type="number"
+				min="0"
+				max="100"
+				class="priority-input"
+				:placeholder="t('files_confidential', 'Priority (higher = more important)')"
+				@input="$emit('change')">
+		</label>
 		<div class="options">
 			<div class="option">
 				<label>
@@ -244,6 +254,17 @@ export default {
 </script>
 
 <style scoped>
+.priority-label {
+	display: flex;
+	align-items: center;
+	margin-top: 10px;
+}
+
+.priority-input {
+	width: 80px;
+	margin-left: 10px;
+}
+
 .option.regex,
 .option.keywords,
 .option.metadata .field {

--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -135,9 +135,10 @@ export default {
 				return
 			}
 			this.labels.push({
-				id: Math.random(),
+				id: crypto.randomUUID(),
 				index: this.labels.length,
 				tag: '',
+				priority: 0,
 				keywords: [],
 				categories: [],
 				searchExpressions: [],
@@ -170,7 +171,9 @@ export default {
 		async setValue(setting, value) {
 			if (setting === 'labels') {
 				value = value.map(label => ({
-					...label, tag: String(label?.tag?.id) || '',
+					...label,
+					tag: String(label?.tag?.id) || '',
+					priority: label.priority || 0,
 				}))
 			}
 			try {
@@ -233,13 +236,13 @@ export default {
 			this.tags = await this.getTags()
 			this.searchExpressions = loadState('files_confidential', 'searchExpressions')
 			this.labels = loadState('files_confidential', 'labels')
-				.map(label => ({ ...label, id: Math.random(), tag: this.tags.find(tag => String(tag.id) === String(label.tag)) }))
+				.map(label => ({ ...label, id: crypto.randomUUID(), priority: label.priority || 0, tag: this.tags.find(tag => String(tag.id) === String(label.tag)) }))
 		},
 
 		loadLabels() {
 			axios.get(generateUrl('/apps/files_confidential/admin/settings/labels'))
 				.then(res => {
-					this.labels = res.data.map(label => ({ ...label, id: Math.random(), tag: this.tags.find(tag => String(tag.id) === String(label.tag)) }))
+					this.labels = res.data.map(label => ({ ...label, id: crypto.randomUUID(), priority: label.priority || 0, tag: this.tags.find(tag => String(tag.id) === String(label.tag)) }))
 				})
 		},
 	},

--- a/test/ClassificationServiceTest.php
+++ b/test/ClassificationServiceTest.php
@@ -99,7 +99,29 @@ class ClassificationServiceTest extends TestCase {
 		self::assertNull($predictedLabel);
 	}
 
-	public function testMultipleLabelsFoundReturnsFirstMatch() : void {
+	public function testMultipleLabelsFoundReturnsHighestPriority() : void {
+		$content = 'This document is about email: test@example.com and is CONFIDENTIAL';
+		$this->contentProvider->expects($this->once())
+			->method('getContentStreamForFile')
+			->willReturn($this->createGenerator($content));
+		$this->matcherService->expects($this->any())
+			->method('getMatchExpression')
+			->with('E-Mail')
+			->willReturn('/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/');
+
+		$this->metadataProvider->expects($this->once())->method('getMetadataForFile')->willReturn([]);
+		$this->bailsProvider->expects($this->once())->method('getPolicyForFile')->willReturn(null);
+
+		$label1 = new ClassificationLabel(0, 'tag1', ['CONFIDENTIAL'], [], [], [], []);
+		$label2 = new ClassificationLabel(1, 'tag2', [], [], ['E-Mail'], [], [], 10);
+		$this->settings->expects($this->once())->method('getClassificationLabels')->willReturn([$label1, $label2]);
+
+		// label2 has higher priority (10 > 0), so it should be returned
+		$predictedLabel = $this->classificationService->getClassificationLabelForFile($this->createMock(File::class));
+		self::assertSame($label2, $predictedLabel);
+	}
+
+	public function testMultipleLabelsFoundReturnsAllMatches() : void {
 		$content = 'This document is about email: test@example.com and is CONFIDENTIAL';
 		$this->contentProvider->expects($this->once())
 			->method('getContentStreamForFile')
@@ -116,8 +138,12 @@ class ClassificationServiceTest extends TestCase {
 		$label2 = new ClassificationLabel(1, 'tag2', [], [], ['E-Mail'], [], []);
 		$this->settings->expects($this->once())->method('getClassificationLabels')->willReturn([$label1, $label2]);
 
-		$predictedLabel = $this->classificationService->getClassificationLabelForFile($this->createMock(File::class));
-		self::assertSame($label2, $predictedLabel);
+		// Both labels should be found when using getClassificationLabelsForFile
+		$predictedLabels = $this->classificationService->getClassificationLabelsForFile($this->createMock(File::class));
+		self::assertCount(2, $predictedLabels);
+		// Default priority (0) for both, so sorted by index
+		self::assertSame($label1, $predictedLabels[0]);
+		self::assertSame($label2, $predictedLabels[1]);
 	}
 
 	public function testMetadataClassificationPositive() : void {
@@ -234,5 +260,137 @@ class ClassificationServiceTest extends TestCase {
 
 		$predictedLabel = $this->classificationService->getClassificationLabelForFile($this->createMock(File::class));
 		self::assertSame($targetLabel, $predictedLabel);
+	}
+
+	public function testPriorityHigherValueWins(): void {
+		$content = 'This document contains CONFIDENTIAL information and also has an IBAN: AL35202111090000000001234567';
+		$this->contentProvider->expects($this->once())
+			->method('getContentStreamForFile')
+			->willReturn($this->createGenerator($content));
+		$this->matcherService->expects($this->any())
+			->method('getMatchExpression')
+			->with('IBAN')
+			->willReturn('/\b([A-Z]{2}[ \-]?[0-9]{2})(?=(?:[ \-]?[A-Z0-9]){9,30}\b)((?:[ \-]?[A-Z0-9]{3,5}){2,7})([ \-]?[A-Z0-9]{1,3})?\b/');
+
+		$this->metadataProvider->expects($this->once())->method('getMetadataForFile')->willReturn([]);
+		$this->bailsProvider->expects($this->once())->method('getPolicyForFile')->willReturn(null);
+
+		$lowPriorityLabel = new ClassificationLabel(0, 'INTERNAL', ['CONFIDENTIAL'], [], [], [], [], 1);
+		$highPriorityLabel = new ClassificationLabel(1, 'PII', [], [], ['IBAN'], [], [], 10);
+		$this->settings->expects($this->once())->method('getClassificationLabels')->willReturn([
+			$lowPriorityLabel,
+			$highPriorityLabel,
+		]);
+
+		// Higher priority label (PII, priority=10) should be returned first
+		$predictedLabel = $this->classificationService->getClassificationLabelForFile($this->createMock(File::class));
+		self::assertSame($highPriorityLabel, $predictedLabel);
+	}
+
+	public function testPriorityTiebreakByIndex(): void {
+		$content = 'This document contains CONFIDENTIAL info and RESTRICTED data';
+		$this->contentProvider->expects($this->once())
+			->method('getContentStreamForFile')
+			->willReturn($this->createGenerator($content));
+
+		$this->metadataProvider->expects($this->once())->method('getMetadataForFile')->willReturn([]);
+		$this->bailsProvider->expects($this->once())->method('getPolicyForFile')->willReturn(null);
+
+		// Same priority, different index — lower index wins
+		$label1 = new ClassificationLabel(0, 'tag1', ['CONFIDENTIAL'], [], [], [], [], 5);
+		$label2 = new ClassificationLabel(1, 'tag2', ['RESTRICTED'], [], [], [], [], 5);
+		$this->settings->expects($this->once())->method('getClassificationLabels')->willReturn([$label1, $label2]);
+
+		$predictedLabel = $this->classificationService->getClassificationLabelForFile($this->createMock(File::class));
+		self::assertSame($label1, $predictedLabel);
+	}
+
+	public function testGetClassificationLabelsForFileReturnsAllMatches(): void {
+		$content = 'This document has SSN: 123-45-6789 and IBAN: AL35202111090000000001234567';
+		$this->contentProvider->expects($this->once())
+			->method('getContentStreamForFile')
+			->willReturn($this->createGenerator($content));
+		$this->matcherService->expects($this->any())
+			->method('getMatchExpression')
+			->willReturnMap([
+				['IBAN', '/\b([A-Z]{2}[ \-]?[0-9]{2})(?=(?:[ \-]?[A-Z0-9]){9,30}\b)((?:[ \-]?[A-Z0-9]{3,5}){2,7})([ \-]?[A-Z0-9]{1,3})?\b/'],
+				['SSN', '/\b\d{3}-\d{2}-\d{4}\b/'],
+			]);
+
+		$this->metadataProvider->expects($this->once())->method('getMetadataForFile')->willReturn([]);
+		$this->bailsProvider->expects($this->once())->method('getPolicyForFile')->willReturn(null);
+
+		$ibanLabel = new ClassificationLabel(0, 'FINANCIAL', [], [], ['IBAN'], [], [], 5);
+		$ssnLabel = new ClassificationLabel(1, 'PII', [], [], ['SSN'], [], [], 10);
+		$this->settings->expects($this->once())->method('getClassificationLabels')->willReturn([
+			$ibanLabel,
+			$ssnLabel,
+		]);
+
+		$labels = $this->classificationService->getClassificationLabelsForFile($this->createMock(File::class));
+		self::assertCount(2, $labels);
+		// Sorted by priority: PII (10) first, FINANCIAL (5) second
+		self::assertSame($ssnLabel, $labels[0]);
+		self::assertSame($ibanLabel, $labels[1]);
+	}
+
+	public function testGetClassificationLabelsForFileMixedSources(): void {
+		$content = 'This document contains CONFIDENTIAL information';
+		$this->contentProvider->expects($this->once())
+			->method('getContentStreamForFile')
+			->willReturn($this->createGenerator($content));
+
+		$this->metadataProvider->expects($this->once())->method('getMetadataForFile')->willReturn([
+			new MetadataItem('RESTRICTION', 'HIGH'),
+		]);
+		$this->bailsProvider->expects($this->once())->method('getPolicyForFile')->willReturn(null);
+
+		$contentLabel = new ClassificationLabel(0, 'INTERNAL', ['CONFIDENTIAL'], [], [], [], [], 1);
+		$metadataLabel = new ClassificationLabel(1, 'RESTRICTED', [], [], [], [], [
+			new MetadataItem('RESTRICTION', 'HIGH'),
+		], 5);
+		$this->settings->expects($this->once())->method('getClassificationLabels')->willReturn([
+			$contentLabel,
+			$metadataLabel,
+		]);
+
+		// Both match — one from content, one from metadata
+		$labels = $this->classificationService->getClassificationLabelsForFile($this->createMock(File::class));
+		self::assertCount(2, $labels);
+		// metadataLabel has higher priority
+		self::assertSame($metadataLabel, $labels[0]);
+		self::assertSame($contentLabel, $labels[1]);
+	}
+
+	public function testDefaultPriorityIsZero(): void {
+		// Labels created without explicit priority should default to 0
+		$label = new ClassificationLabel(0, 'tag1', ['keyword'], [], [], [], []);
+		self::assertSame(0, $label->getPriority());
+	}
+
+	public function testPriorityInToArrayAndFromArray(): void {
+		$label = new ClassificationLabel(0, 'tag1', ['keyword'], ['cat1'], ['expr1'], ['regex1'], [], 7);
+		$array = $label->toArray();
+
+		self::assertSame(7, $array['priority']);
+
+		$restored = ClassificationLabel::fromArray($array);
+		self::assertSame(7, $restored->getPriority());
+	}
+
+	public function testFromArrayBackwardCompatibleWithoutPriority(): void {
+		// Simulates loading a label saved before the priority field existed
+		$array = [
+			'index' => 0,
+			'tag' => 'CONFIDENTIAL',
+			'keywords' => ['secret'],
+			'categories' => [],
+			'searchExpressions' => [],
+			'regularExpressions' => [],
+			'metadataItems' => [],
+		];
+
+		$label = ClassificationLabel::fromArray($array);
+		self::assertSame(0, $label->getPriority());
 	}
 }


### PR DESCRIPTION

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

## Description

Adds an explicit priority field to classification labels so admins can
control which tag takes precedence when multiple rules match a document.
All matching tags are now assigned to files (not just the highest-priority
one), enabling scenarios like tagging a document as both PII and Internal.

Higher priority value = higher importance. When priority is equal, the
label order (index) is used as tiebreaker. Fully backward-compatible
with existing configurations (default priority is 0).